### PR TITLE
Fix circular import

### DIFF
--- a/bot/handlers/user/main.py
+++ b/bot/handlers/user/main.py
@@ -21,7 +21,6 @@ from bot.localization import t
 from bot.logger_mesh import logger
 from bot.misc import TgConfig, EnvKeys
 from bot.misc.payment import quick_pay, check_payment_status
-from bot.main import dp
 
 
 
@@ -291,7 +290,6 @@ async def buy_item_callback_handler(call: CallbackQuery):
                                 reply_markup=back(f'item_{item_name}'))
 
 # Home button callback handler
-@dp.callback_query_handler(lambda c: c.data == "home_menu")
 async def process_home_menu(call: CallbackQuery):
     await call.message.delete()  # Delete the purchase confirmation message
     # Show main menu (replace with your menu logic)
@@ -626,6 +624,8 @@ def register_user_handlers(dp: Dispatcher):
                                        lambda c: c.data.startswith('buy_'))
     dp.register_callback_query_handler(checking_payment,
                                        lambda c: c.data.startswith('check_'))
+    dp.register_callback_query_handler(process_home_menu,
+                                       lambda c: c.data == 'home_menu')
 
     dp.register_message_handler(process_replenish_balance,
                                 lambda c: TgConfig.STATE.get(c.from_user.id) == 'process_replenish_balance')


### PR DESCRIPTION
## Summary
- avoid circular import in user handlers
- register home menu callback via dispatcher

## Testing
- `python run.py` *(fails: ModuleNotFoundError: No module named 'aiogram')*
- `pip install -r requirements.txt` *(fails: Failed to build aiohttp)*

------
https://chatgpt.com/codex/tasks/task_b_685a9513c33c8320a2222a28a8eacfe3