### PR TITLE
Fix circular import and persist language

### DIFF
--- a/bot/database/methods/create.py
+++ b/bot/database/methods/create.py
@@ -5,7 +5,7 @@ from bot.database.models import User, ItemValues, Goods, Categories, BoughtGoods
 from bot.database import Database
 
 
-def create_user(telegram_id: int, registration_date, referral_id, role: int = 1) -> None:
+def create_user(telegram_id: int, registration_date, referral_id, role: int = 1, language: str | None = None) -> None:
     session = Database().session
     try:
         session.query(User.telegram_id).filter(User.telegram_id == telegram_id).one()
@@ -13,12 +13,12 @@ def create_user(telegram_id: int, registration_date, referral_id, role: int = 1)
         if referral_id != '':
             session.add(
                 User(telegram_id=telegram_id, role_id=role, registration_date=registration_date,
-                     referral_id=referral_id))
+                     referral_id=referral_id, language=language))
             session.commit()
         else:
             session.add(
                 User(telegram_id=telegram_id, role_id=role, registration_date=registration_date,
-                     referral_id=None))
+                     referral_id=None, language=language))
             session.commit()
 
 

--- a/bot/database/methods/read.py
+++ b/bot/database/methods/read.py
@@ -94,6 +94,11 @@ def get_user_balance(telegram_id: int) -> float | None:
     return result[0] if result else None
 
 
+def get_user_language(telegram_id: int) -> str | None:
+    result = Database().session.query(User.language).filter(User.telegram_id == telegram_id).first()
+    return result[0] if result else None
+
+
 def get_all_admins() -> list[int]:
     return [admin[0] for admin in Database().session.query(User.telegram_id).filter(User.role_id == 'ADMIN').all()]
 

--- a/bot/database/methods/update.py
+++ b/bot/database/methods/update.py
@@ -16,6 +16,12 @@ def update_balance(telegram_id: int | str, summ: int) -> None:
     Database().session.commit()
 
 
+def update_user_language(telegram_id: int, language: str) -> None:
+    Database().session.query(User).filter(User.telegram_id == telegram_id).update(
+        values={User.language: language})
+    Database().session.commit()
+
+
 def buy_item_for_balance(telegram_id: str, summ: int) -> int:
     old_balance = User.balance
     new_balance = old_balance - summ

--- a/bot/database/models/main.py
+++ b/bot/database/models/main.py
@@ -75,6 +75,7 @@ class User(Database.BASE):
     telegram_id = Column(BigInteger, nullable=False, unique=True, primary_key=True)
     role_id = Column(Integer, ForeignKey('roles.id'), default=1)
     balance = Column(BigInteger, nullable=False, default=0)
+    language = Column(String(5), nullable=True)
     referral_id = Column(BigInteger, nullable=True)
     registration_date = Column(VARCHAR, nullable=False)
     user_operations = relationship("Operations", back_populates="user_telegram_id")
@@ -82,12 +83,13 @@ class User(Database.BASE):
     user_goods = relationship("BoughtGoods", back_populates="user_telegram_id")
 
     def __init__(self, telegram_id: int, registration_date: datetime.datetime, balance: int = 0,
-                 referral_id=None, role_id: int = 1):
+                 referral_id=None, role_id: int = 1, language: str | None = None):
         self.telegram_id = telegram_id
         self.role_id = role_id
         self.balance = balance
         self.referral_id = referral_id
         self.registration_date = registration_date
+        self.language = language
 
 
 class Categories(Database.BASE):


### PR DESCRIPTION
## Summary
- avoid circular import in user handlers
- keep user's language in database
- register home menu callback via dispatcher

## Testing
- `python run.py` *(fails: ModuleNotFoundError: No module named 'aiogram')*
- `pip install -r requirements.txt` *(fails: Failed to build aiohttp)*

------
https://chatgpt.com/codex/tasks/task_b_685a9513c33c8320a2222a28a8eacfe3