### PR TITLE
Add SHKeeper crypto payments

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,5 @@ TOKEN=7932162666:AAGl8kdyztCg5ElJ2NxRU3rZHL8wSWfWHaI
 OWNER_ID=8019666279
 ACCESS_TOKEN=<your_yoomoney_token>
 ACCOUNT_NUMBER=<your_account_number>
+SHK_API_KEY=<shkeeper_api_key>
+SHK_MERCHANT_ID=<shkeeper_merchant_id>

--- a/bot/handlers/user/main.py
+++ b/bot/handlers/user/main.py
@@ -18,11 +18,12 @@ from bot.database.methods import (
 from bot.utils.files import cleanup_item_file
 from bot.handlers.other import get_bot_user_ids, check_sub_channel, get_bot_info
 from bot.keyboards import check_sub, main_menu, categories_list, goods_list, subcategories_list, user_items_list, back, item_info, \
-    profile, rules, payment_menu, close
+    profile, rules, payment_menu, close, crypto_choice
 from bot.localization import t
 from bot.logger_mesh import logger
 from bot.misc import TgConfig, EnvKeys
 from bot.misc.payment import quick_pay, check_payment_status
+from bot.misc.crypto_payment import create_invoice, check_transaction_status
 
 
 
@@ -450,14 +451,29 @@ async def process_replenish_balance(message: Message):
                                     reply_markup=back('replenish_balance'))
         return
 
-    label, url = quick_pay(message)
-    start_operation(user_id, text, label)
-    sleep = TgConfig.PAYMENT_TIME
-    sleep_time = int(sleep)
-    markup = payment_menu(url, label)
+    TgConfig.STATE[f'{user_id}_amount'] = text
+    markup = crypto_choice()
     await bot.edit_message_text(chat_id=message.chat.id,
                                 message_id=message_id,
-                                text=f'💵 Top-up amount: {text}€.\n'
+                                text=f'💵 Top-up amount: {text}€. Choose payment method:',
+                                reply_markup=markup)
+
+
+async def pay_yoomoney(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    amount = TgConfig.STATE.pop(f'{user_id}_amount', None)
+    if not amount:
+        await call.answer(text='❌ Invoice not found')
+        return
+
+    fake = type('Fake', (), {'text': amount, 'from_user': call.from_user})
+    label, url = quick_pay(fake)
+    start_operation(user_id, amount, label)
+    sleep_time = int(TgConfig.PAYMENT_TIME)
+    markup = payment_menu(url, label)
+    await bot.edit_message_text(chat_id=call.message.chat.id,
+                                message_id=call.message.message_id,
+                                text=f'💵 Top-up amount: {amount}€.\n'
                                      f'⌛️ You have {int(sleep_time / 60)} minutes to pay.\n'
                                      f'<b>❗️ After payment press "Check payment"</b>',
                                 reply_markup=markup)
@@ -465,9 +481,36 @@ async def process_replenish_balance(message: Message):
     info = select_unfinished_operations(label)
     if info:
         payment_status = await check_payment_status(label)
-
-        if not payment_status == "success":
+        if payment_status is None:
+            payment_status = await check_transaction_status(label)
+        if payment_status not in ('paid', 'success'):
             finish_operation(label)
+
+
+async def crypto_payment(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    currency = call.data.split('_')[1]
+    amount = TgConfig.STATE.pop(f'{user_id}_amount', None)
+    if not amount:
+        await call.answer(text='❌ Invoice not found')
+        return
+
+    invoice_id, url = await create_invoice(float(amount), currency)
+    start_operation(user_id, amount, invoice_id)
+    sleep_time = int(TgConfig.PAYMENT_TIME)
+    markup = payment_menu(url, invoice_id)
+    await bot.edit_message_text(chat_id=call.message.chat.id,
+                                message_id=call.message.message_id,
+                                text=(f'💵 Send {amount}€ in {currency}.\n'
+                                      f'⌛️ You have {int(sleep_time / 60)} minutes to pay.\n'
+                                      f'<b>❗️ After payment press "Check payment"</b>'),
+                                reply_markup=markup)
+    await asyncio.sleep(sleep_time)
+    info = select_unfinished_operations(invoice_id)
+    if info:
+        status = await check_transaction_status(invoice_id)
+        if status not in ('paid', 'success'):
+            finish_operation(invoice_id)
 
 
 async def checking_payment(call: CallbackQuery):
@@ -479,8 +522,10 @@ async def checking_payment(call: CallbackQuery):
     if info:
         operation_value = info[0]
         payment_status = await check_payment_status(label)
+        if payment_status is None:
+            payment_status = await check_transaction_status(label)
 
-        if payment_status == "success":
+        if payment_status in ("success", "paid"):
             current_time = datetime.datetime.now()
             formatted_time = current_time.strftime("%Y-%m-%d %H:%M:%S")
             referral_id = get_user_referral(user_id)
@@ -634,6 +679,10 @@ def register_user_handlers(dp: Dispatcher):
                                        lambda c: c.data.startswith('item_'))
     dp.register_callback_query_handler(buy_item_callback_handler,
                                        lambda c: c.data.startswith('buy_'))
+    dp.register_callback_query_handler(pay_yoomoney,
+                                       lambda c: c.data == 'pay_yoomoney')
+    dp.register_callback_query_handler(crypto_payment,
+                                       lambda c: c.data.startswith('crypto_'))
     dp.register_callback_query_handler(checking_payment,
                                        lambda c: c.data.startswith('check_'))
     dp.register_callback_query_handler(process_home_menu,

--- a/bot/keyboards/inline.py
+++ b/bot/keyboards/inline.py
@@ -253,6 +253,18 @@ def payment_menu(url: str, label: str) -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
 
 
+def crypto_choice() -> InlineKeyboardMarkup:
+    inline_keyboard = [
+        [InlineKeyboardButton('ETH', callback_data='crypto_ETH'),
+         InlineKeyboardButton('SOL', callback_data='crypto_SOL')],
+        [InlineKeyboardButton('BTC', callback_data='crypto_BTC'),
+         InlineKeyboardButton('XRP', callback_data='crypto_XRP')],
+        [InlineKeyboardButton('💳 Card', callback_data='pay_yoomoney')],
+        [InlineKeyboardButton('🔙 Go back', callback_data='replenish_balance')]
+    ]
+    return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
+
+
 def reset_config(key: str) -> InlineKeyboardMarkup:
     inline_keyboard = [
         [InlineKeyboardButton(f'Reset {key}', callback_data=f'reset_{key}')

--- a/bot/misc/crypto_payment.py
+++ b/bot/misc/crypto_payment.py
@@ -1,0 +1,30 @@
+import requests
+from bot.misc.env import EnvKeys
+
+BASE_URL = 'https://shkeeper.io/api/v1'
+
+
+async def create_invoice(amount: float, currency: str):
+    payload = {
+        'merchant_id': EnvKeys.SHK_MERCHANT_ID,
+        'api_key': EnvKeys.SHK_API_KEY,
+        'amount': amount,
+        'currency': currency.upper(),
+    }
+    response = requests.post(f'{BASE_URL}/invoice', json=payload, timeout=10)
+    response.raise_for_status()
+    data = response.json()
+    invoice_id = str(data.get('id'))
+    url = data.get('payment_url') or data.get('url') or data.get('address')
+    return invoice_id, url
+
+
+async def check_transaction_status(invoice_id: str):
+    params = {
+        'merchant_id': EnvKeys.SHK_MERCHANT_ID,
+        'api_key': EnvKeys.SHK_API_KEY,
+    }
+    response = requests.get(f'{BASE_URL}/invoice/{invoice_id}', params=params, timeout=10)
+    response.raise_for_status()
+    data = response.json()
+    return data.get('status')

--- a/bot/misc/env.py
+++ b/bot/misc/env.py
@@ -11,3 +11,5 @@ class EnvKeys(ABC):
     OWNER_ID: Final = os.environ.get('OWNER_ID')
     ACCESS_TOKEN: Final = os.environ.get('ACCESS_TOKEN')
     ACCOUNT_NUMBER: Final = os.environ.get('ACCOUNT_NUMBER')
+    SHK_API_KEY: Final = os.environ.get('SHK_API_KEY')
+    SHK_MERCHANT_ID: Final = os.environ.get('SHK_MERCHANT_ID')

--- a/markdown/quick_start.md
+++ b/markdown/quick_start.md
@@ -12,6 +12,8 @@
       - [OWNER_ID](https://telegram.me/myidbot)
       - [ACCESS_TOKEN](https://pypi.org/project/YooMoney/#access-token)
       - [ACCOUNT_NUMBER](https://pypi.org/project/YooMoney/#account-information)
+      - `SHK_API_KEY` - SHKeeper API key
+      - `SHK_MERCHANT_ID` - SHKeeper merchant id
 
    5. [Setup config.py](../bot/misc/config.py)
       - CHANNEL_URL - telegram channel link (to disable, set `CHANNEL_URL: Final = 'https://t.me/'`)


### PR DESCRIPTION
## Summary
- add `crypto_payment` module for SHKeeper integration
- extend environment variables for SHKeeper API keys
- allow choosing cryptocurrencies when topping up balance
- handle Yoomoney or crypto invoices in user handlers
- document new env vars

## Testing
- `python -m py_compile bot/misc/crypto_payment.py bot/handlers/user/main.py bot/keyboards/inline.py bot/misc/env.py`

------
https://chatgpt.com/codex/tasks/task_b_685aa0cf55e88320ab7f40b4aa6e9699